### PR TITLE
OI-282 Pre release fixes.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,8 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "composer/installers": "^1.2",
+        "drupal/ajax_comments": "1.x-dev#4b0c423",
+        "drupal/ckeditor_mentions": "2.x-dev#272a28e7",
         "drupal/core-composer-scaffold": "^8.8",
         "drupal/core-project-message": "^8.8",
         "drupal/core-recommended": "^8.8",


### PR DESCRIPTION
Tested the installation of profile via composer create-project, and results of tests are:
   * when set hash of package in nested composer.json (in our case inside profile itself), composer initially downloads default version of the module and then asks to make a checkout to a branch. 
   * if set these packages in the main repository composer downloads the exact version without checkout.